### PR TITLE
Change pinecone metadata from filename to file path

### DIFF
--- a/server/services/pinecone_services.py
+++ b/server/services/pinecone_services.py
@@ -161,7 +161,7 @@ def main():
                         'id': f"doc_{count}",
                         'values': embedding,
                         'metadata': {
-                            'filename': file
+                            'file_path': file_path
                         }
                     }
                     


### PR DESCRIPTION
Changes the metadata for the pinecone index from a filename to a file path for faster rag search results