### PR TITLE
Added the ability to display chatbot results as stylized markdown

### DIFF
--- a/frontend/src/components/MessageItem/MessageItem.jsx
+++ b/frontend/src/components/MessageItem/MessageItem.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 import styles from './MessageItem.module.css'; // Assuming you're using CSS modules
 
 const MessageItem = ({ message }) => {
@@ -17,7 +18,9 @@ const MessageItem = ({ message }) => {
       </div>
       <div className={styles.messageContent}>
         <div className={styles.role}>{isUser ? "You" : "MediSeek"}</div>
-        <div className={styles.text}>{message.content}</div>
+        <div className={styles.text}>
+          <ReactMarkdown>{message.content}</ReactMarkdown>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/MessageItem/MessageItem.module.css
+++ b/frontend/src/components/MessageItem/MessageItem.module.css
@@ -41,7 +41,7 @@
 
 .text {
   color: rgba(255, 255, 255, 0.9);
-  line-height: 1.5;
-  white-space: pre-wrap;
+  line-height: 2;
+  white-space: normal;
 }
 


### PR DESCRIPTION
- Added ReactMarkdown to MessageItem.jsx to display the message output from the LLM as stylized markdown
- Changed the css styling for text in MessageItem.module.css to have a line height of 2 and changed white-space from pre-wrap to normal to avoid weird spacing issues when displaying the markdown 